### PR TITLE
Publicize office hours

### DIFF
--- a/src/DssExec.sol
+++ b/src/DssExec.sol
@@ -36,14 +36,12 @@ contract DssExec {
     bytes           public sig;
     uint256         public expiration;
     bool            public done;
+    bool            public officeHours;
 
     // Provides a descriptive tag for bot consumption
     // This should be modified weekly to provide a summary of the actions
     // Hash: seth keccak -- "$(wget https://raw.githubusercontent.com/makerdao/community/d8496d07a5eae08f2d1886f6bf4de1a813b4584d/governance/votes/Executive%20vote%20-%20September%204%2C%202020.md -q -O - 2>/dev/null)"
     string          public description;
-
-    bool            private officeHours;
-    address         private spellAction;
 
     // @param _description  A string description of the spell
     // @param _expiration   The timestamp this spell will expire. (Ex. now + 30 days)

--- a/src/test/DssExec.t.sol
+++ b/src/test/DssExec.t.sol
@@ -407,5 +407,8 @@ contract DssLibExecTest is DSTest, DSMath {
 
         checkSystemValues(afterSpell);
         checkCollateralValues("ETH-A",  afterSpell);
+
+        assertTrue(spell.officeHours());
+        assertTrue(spell.action() != address(0));
     }
 }


### PR DESCRIPTION
Request from integrations to make officeHours public so keepers know to hold off on cast attempts.

* publicized the `officeHours` var
* removed an unused `spellAction` var
* add a test for officehours and action