### PR TITLE
Add contract deployment estimate

### DIFF
--- a/estimate-gas.sh
+++ b/estimate-gas.sh
@@ -1,0 +1,5 @@
+
+#!/usr/bin/env bash
+
+BIN=`jq '.contracts|.["src/DssExecLib.sol:DssExecLib"]|.bin' ./out/dapp.sol.json | sed 's/"//g'`
+echo "DssExecLib: $(seth estimate --create 0x${BIN} "DssExecLib()")"


### PR DESCRIPTION
Lifted from Kurt's estimation script in spells-mainnet. Not sure how useful this is though, estimated result was 5.6mm gas. Actual mainnet [deployment](https://etherscan.io/address/0x5f1759a86a515d61db55a8002b34693dbd321dbd) was 3,402,004 