### PR TITLE
Add monthly helper, weekly helper, test updates

### DIFF
--- a/src/DssExecFactory.sol
+++ b/src/DssExecFactory.sol
@@ -31,4 +31,12 @@ contract DssExecFactory {
     function newExec(string memory description, uint256 expiration, bool officeHours, address spellAction) public returns (address exec) {
         exec = address(new DssExec(description, expiration, officeHours, spellAction));
     }
+
+    function newWeeklyExec(string memory description, address spellAction) public returns (address exec) {
+        exec = newExec(description, now + 30 days, true, spellAction);
+    }
+
+    function newMonthlyExec(string memory description, address spellAction) public returns (address exec) {
+        exec = newExec(description, now + 4 days, true, spellAction);
+    }
 }

--- a/src/test/DssExec.t.sol
+++ b/src/test/DssExec.t.sol
@@ -223,7 +223,7 @@ contract DssLibExecTest is DSTest, DSMath {
             vow_bump:     10000,           // In whole Dai units
             vow_hump:     4 * MILLION,     // In whole Dai units
             cat_box:      15 * MILLION,    // In whole Dai units
-            ilk_count:    16               // Num expected in system
+            ilk_count:    19               // Num expected in system
         });
 
         //
@@ -231,7 +231,7 @@ contract DssLibExecTest is DSTest, DSMath {
         //
         afterSpell.collaterals["ETH-A"] = CollateralValues({
             line:         10 * MILLION,    // In whole Dai units
-            dust:         100,             // In whole Dai units
+            dust:         500,             // In whole Dai units
             pct:          200,             // In basis points
             chop:         1300,            // In basis points
             dunk:         50 * THOUSAND,   // In whole Dai units
@@ -244,7 +244,7 @@ contract DssLibExecTest is DSTest, DSMath {
         // New collateral
         afterSpell.collaterals["XMPL-A"] = CollateralValues({
             line:         3 * MILLION,     // In whole Dai units
-            dust:         100,             // In whole Dai units
+            dust:         500,             // In whole Dai units
             pct:          225,             // In basis points
             chop:         1300,            // In basis points
             dunk:         50 * THOUSAND,   // In whole Dai units

--- a/src/test/DssExecFactory.t.sol
+++ b/src/test/DssExecFactory.t.sol
@@ -235,7 +235,7 @@ contract DssLibExecTest is DSTest, DSMath {
             vow_bump:     10000,           // In whole Dai units
             vow_hump:     4 * MILLION,     // In whole Dai units
             cat_box:      15 * MILLION,    // In whole Dai units
-            ilk_count:    16               // Num expected in system
+            ilk_count:    19               // Num expected in system
         });
 
         //
@@ -243,7 +243,7 @@ contract DssLibExecTest is DSTest, DSMath {
         //
         afterSpell.collaterals["ETH-A"] = CollateralValues({
             line:         10 * MILLION,    // In whole Dai units
-            dust:         100,             // In whole Dai units
+            dust:         500,             // In whole Dai units
             pct:          200,             // In basis points
             chop:         1300,            // In basis points
             dunk:         50 * THOUSAND,   // In whole Dai units
@@ -256,7 +256,7 @@ contract DssLibExecTest is DSTest, DSMath {
         // New collateral
         afterSpell.collaterals["XMPL-A"] = CollateralValues({
             line:         3 * MILLION,     // In whole Dai units
-            dust:         100,             // In whole Dai units
+            dust:         500,             // In whole Dai units
             pct:          225,             // In basis points
             chop:         1300,            // In basis points
             dunk:         50 * THOUSAND,   // In whole Dai units
@@ -574,8 +574,18 @@ contract DssLibExecTest is DSTest, DSMath {
         assertEq(flipXMPLA.kicks(), 1);
     }
 
-    function testExecFactoryDeployCost() public {
-        new DssExecFactory();
+    function testExecFactoryWeeklyDeploy() public {
+        DssExecFactory fac = new DssExecFactory();
+        DssExec spl = DssExec(fac.newWeeklyExec("A test dss exec spell", address(action)));
+        assertEq(spl.expiration(), now + 30 days);
+        assertTrue(spl.officeHours());
+    }
+
+    function testExecFactoryMonthlyDeploy() public {
+        DssExecFactory fac = new DssExecFactory();
+        DssExec spl = DssExec(fac.newMonthlyExec("A test dss exec spell", address(action)));
+        assertEq(spl.expiration(), now + 4 days);
+        assertTrue(spl.officeHours());
     }
 
     function testExecFactoryNewExecDeployCost() public {


### PR DESCRIPTION
* Adds monthly and weekly exec helpers to the factory for ease of timestamp generation
* Adds tests of same
* Fixes tests to match system values

These tests were ported from the spells-mainnet repo and should probably be redesigned to not rely on hardcoded system info, instead loading at runtime in the tests.