### PR TITLE
ExecLib Review

### DIFF
--- a/src/DssAction.sol
+++ b/src/DssAction.sol
@@ -258,7 +258,7 @@ abstract contract DssAction {
     }
 
     function setDAIReferenceValue(uint256 value) internal {
-        libcall(abi.encodeWithSignature("setDAIReferenceValue(address,uint256)", spot(),value));
+        libcall(abi.encodeWithSignature("setDAIReferenceValue(address,uint256)", spot(), value));
     }
 
     /*****************************/
@@ -268,12 +268,20 @@ abstract contract DssAction {
         libcall(abi.encodeWithSignature("setIlkDebtCeiling(address,bytes32,uint256)", vat(), ilk, amount));
     }
 
+    function increaseIlkDebtCeiling(bytes32 ilk, uint256 amount, bool global) internal {
+        libcall(abi.encodeWithSignature("increaseIlkDebtCeiling(address,bytes32,uint256,bool)", vat(), ilk, amount, global));
+    }
+
     function increaseIlkDebtCeiling(bytes32 ilk, uint256 amount) internal {
-        libcall(abi.encodeWithSignature("increaseIlkDebtCeiling(address,bytes32,uint256,bool)", vat(), ilk, amount, true));
+        increaseIlkDebtCeiling(ilk, amount, true);
+    }
+
+    function decreaseIlkDebtCeiling(bytes32 ilk, uint256 amount, bool global) internal {
+        libcall(abi.encodeWithSignature("decreaseIlkDebtCeiling(address,bytes32,uint256,bool)", vat(), ilk, amount, global));
     }
 
     function decreaseIlkDebtCeiling(bytes32 ilk, uint256 amount) internal {
-        libcall(abi.encodeWithSignature("decreaseIlkDebtCeiling(address,bytes32,uint256,bool)", vat(), ilk, amount, true));
+        decreaseIlkDebtCeiling(ilk, amount, true);
     }
 
     function setIlkAutoLineParameters(bytes32 ilk, uint256 amount, uint256 gap, uint256 ttl) internal {
@@ -316,8 +324,12 @@ abstract contract DssAction {
         libcall(abi.encodeWithSignature("setIlkAuctionDuration(address,uint256)", flip(ilk), duration));
     }
 
+    function setIlkStabilityFee(bytes32 ilk, uint256 rate, bool doDrip) internal {
+        libcall(abi.encodeWithSignature("setIlkStabilityFee(address,bytes32,uint256,bool)", jug(), ilk, rate, doDrip));
+    }
+
     function setIlkStabilityFee(bytes32 ilk, uint256 rate) internal {
-        libcall(abi.encodeWithSignature("setIlkStabilityFee(address,bytes32,uint256,bool)", jug(), ilk, rate, true));
+        setIlkStabilityFee(ilk, rate, true);
     }
 
     /***********************/

--- a/src/DssExecLib.sol
+++ b/src/DssExecLib.sol
@@ -264,7 +264,7 @@ contract DssExecLib {
         @param _rate   The accumulated rate (ex. 4% => 1000000001243680656318820312)
     */
     function setDSR(address _pot, uint256 _rate) public {
-        require((_rate >= MathLib.RAY) && (_rate < 2 * MathLib.RAY));  // "LibDssExec/dsr-out-of-bounds"
+        require((_rate >= MathLib.RAY) && (_rate <= MathLib.RATES_ONE_HUNDRED_PCT));  // "LibDssExec/dsr-out-of-bounds"
         Fileable(_pot).file("dsr", _rate);
     }
     /**
@@ -292,8 +292,8 @@ contract DssExecLib {
         @param _pct_bps The pct, in basis points, to set in integer form (x100). (ex. 5% = 5 * 100 = 500)
     */
     function setMinSurplusAuctionBidIncrease(address _flap, uint256 _pct_bps) public {
-        require(_pct_bps < 10 * MathLib.THOUSAND);  // "LibDssExec/incorrect-flap-beg-precision"
-        Fileable(_flap).file("beg", MathLib.add(MathLib.WAD, MathLib.wdiv(_pct_bps, 10 * MathLib.THOUSAND)));
+        require(_pct_bps < MathLib.BPS_ONE_HUNDRED_PCT);  // "LibDssExec/incorrect-flap-beg-precision"
+        Fileable(_flap).file("beg", MathLib.add(MathLib.WAD, MathLib.wdiv(_pct_bps, MathLib.BPS_ONE_HUNDRED_PCT)));
     }
     /**
         @dev Set bid duration for surplus auctions.
@@ -344,8 +344,8 @@ contract DssExecLib {
         @param _pct_bps    The pct, in basis points, to set in integer form (x100). (ex. 5% = 5 * 100 = 500)
     */
     function setMinDebtAuctionBidIncrease(address _flop, uint256 _pct_bps) public {
-        require(_pct_bps < 10 * MathLib.THOUSAND);  // "LibDssExec/incorrect-flap-beg-precision"
-        Fileable(_flop).file("beg", MathLib.add(MathLib.WAD, MathLib.wdiv(_pct_bps, 10 * MathLib.THOUSAND)));
+        require(_pct_bps < MathLib.BPS_ONE_HUNDRED_PCT);  // "LibDssExec/incorrect-flap-beg-precision"
+        Fileable(_flop).file("beg", MathLib.add(MathLib.WAD, MathLib.wdiv(_pct_bps, MathLib.BPS_ONE_HUNDRED_PCT)));
     }
     /**
         @dev Set bid duration for debt auctions.
@@ -371,7 +371,7 @@ contract DssExecLib {
         @param _pct_bps    The pct, in basis points, to set in integer form (x100). (ex. 5% = 5 * 100 = 500)
     */
     function setDebtAuctionMKRIncreaseRate(address _flop, uint256 _pct_bps) public {
-        Fileable(_flop).file("pad", MathLib.add(MathLib.WAD, MathLib.wdiv(_pct_bps, 10 * MathLib.THOUSAND)));
+        Fileable(_flop).file("pad", MathLib.add(MathLib.WAD, MathLib.wdiv(_pct_bps, MathLib.BPS_ONE_HUNDRED_PCT)));
     }
     /**
         @dev Set the maximum total DAI amount that can be out for liquidation in the system at any point. Amount will be converted to the correct internal precision.
@@ -404,7 +404,7 @@ contract DssExecLib {
         @param _rate   The accumulated rate (ex. 4% => 1000000001243680656318820312)
     */
     function setGlobalStabilityFee(address _jug, uint256 _rate) public {
-        require((_rate >= MathLib.RAY) && (_rate < 2 * MathLib.RAY));  // "LibDssExec/global-stability-fee-out-of-bounds"
+        require((_rate >= MathLib.RAY) && (_rate <= MathLib.RATES_ONE_HUNDRED_PCT));  // "LibDssExec/global-stability-fee-out-of-bounds"
         Fileable(_jug).file("base", _rate);
     }
     /**
@@ -505,8 +505,8 @@ contract DssExecLib {
         @param _pct_bps    The pct, in basis points, to set in integer form (x100). (ex. 10.25% = 10.25 * 100 = 1025)
     */
     function setIlkLiquidationPenalty(address _cat, bytes32 _ilk, uint256 _pct_bps) public {
-        require(_pct_bps < 10 * MathLib.THOUSAND);  // "LibDssExec/incorrect-ilk-chop-precision"
-        Fileable(_cat).file(_ilk, "chop", MathLib.add(MathLib.WAD, MathLib.wdiv(_pct_bps, 10 * MathLib.THOUSAND)));
+        require(_pct_bps < MathLib.BPS_ONE_HUNDRED_PCT);  // "LibDssExec/incorrect-ilk-chop-precision"
+        Fileable(_cat).file(_ilk, "chop", MathLib.add(MathLib.WAD, MathLib.wdiv(_pct_bps, MathLib.BPS_ONE_HUNDRED_PCT)));
     }
     /**
         @dev Set max DAI amount for liquidation per vault for collateral. Amount will be converted to the correct internal precision.
@@ -526,9 +526,9 @@ contract DssExecLib {
         @param _pct_bps    The pct, in basis points, to set in integer form (x100). (ex. 150% = 150 * 100 = 15000)
     */
     function setIlkLiquidationRatio(address _spot, bytes32 _ilk, uint256 _pct_bps) public {
-        require(_pct_bps < 100 * MathLib.THOUSAND);  // "LibDssExec/incorrect-ilk-mat-precision" // Fails if pct >= 1000%
-        require(_pct_bps >= 10 * MathLib.THOUSAND); // the liquidation ratio has to be bigger or equal to 100%
-        Fileable(_spot).file(_ilk, "mat", MathLib.rdiv(_pct_bps, 10 * MathLib.THOUSAND));
+        require(_pct_bps < 10 * MathLib.BPS_ONE_HUNDRED_PCT); // "LibDssExec/incorrect-ilk-mat-precision" // Fails if pct >= 1000%
+        require(_pct_bps >= MathLib.BPS_ONE_HUNDRED_PCT); // the liquidation ratio has to be bigger or equal to 100%
+        Fileable(_spot).file(_ilk, "mat", MathLib.rdiv(_pct_bps, MathLib.BPS_ONE_HUNDRED_PCT));
     }
     /**
         @dev Set minimum bid increase for collateral. Amount will be converted to the correct internal precision.
@@ -537,8 +537,8 @@ contract DssExecLib {
         @param _pct_bps    The pct, in basis points, to set in integer form (x100). (ex. 5% = 5 * 100 = 500)
     */
     function setIlkMinAuctionBidIncrease(address _flip, uint256 _pct_bps) public {
-        require(_pct_bps < 10 * MathLib.THOUSAND);  // "LibDssExec/incorrect-ilk-chop-precision"
-        Fileable(_flip).file("beg", MathLib.add(MathLib.WAD, MathLib.wdiv(_pct_bps, 10 * MathLib.THOUSAND)));
+        require(_pct_bps < MathLib.BPS_ONE_HUNDRED_PCT);  // "LibDssExec/incorrect-ilk-chop-precision"
+        Fileable(_flip).file("beg", MathLib.add(MathLib.WAD, MathLib.wdiv(_pct_bps, MathLib.BPS_ONE_HUNDRED_PCT)));
     }
     /**
         @dev Set bid duration for a collateral type.
@@ -573,7 +573,7 @@ contract DssExecLib {
         @param _doDrip `true` to accumulate stability fees for the collateral
     */
     function setIlkStabilityFee(address _jug, bytes32 _ilk, uint256 _rate, bool _doDrip) public {
-        require((_rate >= MathLib.RAY) && (_rate < 2 * MathLib.RAY));  // "LibDssExec/ilk-stability-fee-out-of-bounds"
+        require((_rate >= MathLib.RAY) && (_rate <= MathLib.RATES_ONE_HUNDRED_PCT));  // "LibDssExec/ilk-stability-fee-out-of-bounds"
         if (_doDrip) Drippable(_jug).drip(_ilk);
 
         Fileable(_jug).file(_ilk, "duty", _rate);
@@ -604,12 +604,12 @@ contract DssExecLib {
         // Add new flip address to Cat
         setContract(_cat, _ilk, "flip", _newFlip);
 
-        // Authorize MCD contracts from new flip
+        // Authorize MCD contracts for new flip
         authorize(_newFlip, _cat);
         authorize(_newFlip, _end);
         authorize(_newFlip, _flipperMom);
 
-        // Authorize MCD contracts from old flip
+        // Deauthorize MCD contracts for old flip
         deauthorize(_oldFlip, _cat);
         deauthorize(_oldFlip, _end);
         deauthorize(_oldFlip, _flipperMom);
@@ -635,10 +635,10 @@ contract DssExecLib {
         // Add new flap address to Vow
         setContract(_vow, "flapper", _newFlap);
 
-        // Authorize MCD contracts from new flap
+        // Authorize MCD contracts for new flap
         authorize(_newFlap, _vow);
 
-        // Authorize MCD contracts from old flap
+        // Deauthorize MCD contracts for old flap
         deauthorize(_oldFlap, _vow);
 
         // Transfer auction params from old flap to new flap

--- a/src/MathLib.sol
+++ b/src/MathLib.sol
@@ -26,7 +26,8 @@ library MathLib {
     uint256 constant internal THOUSAND = 10 ** 3;
     uint256 constant internal MILLION  = 10 ** 6;
 
-    uint256 constant internal BPS_ONE_HUNDRED_PCT     = 10 * THOUSAND;
+    uint256 constant internal BPS_ONE_PCT             = 100;
+    uint256 constant internal BPS_ONE_HUNDRED_PCT     = 100 * BPS_ONE_PCT;
     uint256 constant internal RATES_ONE_HUNDRED_PCT   = 1000000021979553151239153027;
 
     // --- SafeMath Functions ---

--- a/src/MathLib.sol
+++ b/src/MathLib.sol
@@ -20,11 +20,14 @@ pragma solidity ^0.6.11;
 
 library MathLib {
 
-    uint256 constant public WAD      = 10 ** 18;
-    uint256 constant public RAY      = 10 ** 27;
-    uint256 constant public RAD      = 10 ** 45;
-    uint256 constant public THOUSAND = 10 ** 3;
-    uint256 constant public MILLION  = 10 ** 6;
+    uint256 constant internal WAD      = 10 ** 18;
+    uint256 constant internal RAY      = 10 ** 27;
+    uint256 constant internal RAD      = 10 ** 45;
+    uint256 constant internal THOUSAND = 10 ** 3;
+    uint256 constant internal MILLION  = 10 ** 6;
+
+    uint256 constant internal BPS_ONE_HUNDRED_PCT     = 10 * THOUSAND;
+    uint256 constant internal RATES_ONE_HUNDRED_PCT   = 1000000021979553151239153027;
 
     // --- SafeMath Functions ---
     function add(uint x, uint y) internal pure returns (uint z) {


### PR DESCRIPTION
Made some fixes after reviewing the exec-lib. This review covers `MathLib.sol`, `DssExecLib.sol` and `DssAction.sol`. I did not cover the other contracts. Proposed changes:

 * Some comment, spacing fixes.
 * Method overloads for the methods with bools.
 * Added two new constants for 100% rates and bps.
 * Replaced the upper limit of stability fees, global SF and DSR to 100% instead of `2 * RAY` as a sane upper limit. `2 * RAY` is some super high number that would be catastrophic to set.
 * MathLib constants changed to internal as we do not want to deploy them as another library.