### PR TITLE
Fix to work with official latest release

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -4,4 +4,4 @@ set -e
 [[ "$ETH_RPC_URL" && "$(seth chain)" == "ethlive"  ]] || { echo "Please set a mainnet ETH_RPC_URL"; exit 1;  }
 
 # SOLC_FLAGS="--optimize --optimize-runs 1" dapp --use solc:0.6.11 build
-dapp --use solc:0.6.11 test -v --rpc
+dapp --use solc:0.6.11 test -v --rpc-url="$ETH_RPC_URL"


### PR DESCRIPTION
`--rpc` doesn't work with latest official release of dapptools yet, only installing `master` branch.
This fix makes the script to work with the latest official release.