### PR TITLE
feat: Added ERC20 DAI payment method

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ Below is an outline of all functions used in the library.
 ### Authorizations
 - `authorize(address _base, address _ward)`: Give an address authorization to perform auth actions on the contract.
 - `deauthorize(address _base, address _ward)`: Revoke contract authorization from an address.
+- `delegateVat(address _usr)`: Delegate vat authority to the specified address.
+- `undelegateVat(address _usr)`: Revoke vat authority to the specified address.
 
 ### Accumulating Rates
 - `accumulateDSR()`: Update rate accumulation for the Dai Savings Rate (DSR).
@@ -199,6 +201,9 @@ setChangelogAddress("MCD_FLIP_XMPL", 0x32c6DF17f8E94694977aa41A595d8dc583836A51)
 - `bidDuration`:          Bid period duration for new collateral
 - `auctionDuration`:      Total auction duration for new collateral
 - `liquidationRatio`:     Percent liquidation ratio for new collateral   [ex. 150% == 15000]
+
+### Payments
+- `sendPaymentFromSurplusBuffer(address _target, uint256 _amount)`: Send a payment in ERC20 DAI from the surplus buffer.
 
 ## Testing
 

--- a/src/DssExecLib.sol
+++ b/src/DssExecLib.sol
@@ -52,7 +52,7 @@ interface DssVat {
     function nope(address) external;
     function ilks(bytes32) external returns (uint256 Art, uint256 rate, uint256 spot, uint256 line, uint256 dust);
     function Line() external view returns (uint256);
-    function suck(address u, address v, uint rad) external;
+    function suck(address, address, uint) external;
 }
 
 interface AuctionLike {
@@ -71,8 +71,8 @@ interface JoinLike {
     function ilk() external returns (bytes32);
     function gem() external returns (address);
     function dec() external returns (uint256);
-    function join(address usr, uint wad) external;
-    function exit(address usr, uint wad) external;
+    function join(address, uint) external;
+    function exit(address, uint) external;
 }
 
 // Includes Median and OSM functions

--- a/src/test/DssAction.t.sol
+++ b/src/test/DssAction.t.sol
@@ -915,9 +915,9 @@ contract ActionTest is DSTest {
     }
 
 
-    /*****************************/
-    /*** Collateral Onboarding ***/
-    /*****************************/
+    /***************/
+    /*** Payment ***/
+    /***************/
 
     function sendPaymentFromSurplusBuffer_test() public {
         address target = address(this);

--- a/src/test/DssAction.t.sol
+++ b/src/test/DssAction.t.sol
@@ -43,9 +43,10 @@ import {Jug}              from 'dss/jug.sol';
 import {Flipper}          from 'dss/flip.sol';
 import {Flapper}          from 'dss/flap.sol';
 import {Flopper}          from 'dss/flop.sol';
-import {GemJoin}          from 'dss/join.sol';
+import {GemJoin,DaiJoin}  from 'dss/join.sol';
 import {End}              from 'dss/end.sol';
 import {Spotter}          from 'dss/spot.sol';
+import {Dai}              from 'dss/dai.sol';
 
 import "../CollateralOpts.sol";
 import {DssTestAction, DssTestNoOfficeHoursAction}    from './DssTestAction.sol';
@@ -62,12 +63,14 @@ interface PipLike {
 contract ActionTest is DSTest {
     Hevm hevm;
 
-    Vat   vat;
-    End   end;
-    Vow   vow;
-    Pot   pot;
-    Jug   jug;
-    Cat   cat;
+    Vat         vat;
+    End         end;
+    Vow         vow;
+    Pot         pot;
+    Jug         jug;
+    Cat         cat;
+    Dai         daiToken;
+    DaiJoin     daiJoin;
 
     DSToken gov;
 
@@ -221,6 +224,11 @@ contract ActionTest is DSTest {
         jug = new Jug(address(vat));
         vat.rely(address(jug));
 
+        daiToken = new Dai(1);
+        daiJoin = new DaiJoin(address(vat), address(daiToken));
+        daiToken.rely(address(daiJoin));
+        daiToken.deny(address(this));
+
         end = new End();
         end.file("vat", address(vat));
         end.file("cat", address(cat));
@@ -264,6 +272,8 @@ contract ActionTest is DSTest {
         log.setAddress("MCD_FLAP",          address(flap));
         log.setAddress("MCD_FLOP",          address(flop));
         log.setAddress("MCD_END",           address(end));
+        log.setAddress("MCD_DAI",           address(daiToken));
+        log.setAddress("MCD_JOIN_DAI",      address(daiJoin));
         log.setAddress("ILK_REGISTRY",      address(reg));
         log.setAddress("OSM_MOM",           address(osmMom));
         log.setAddress("GOV_GUARD",         address(govGuard));
@@ -283,6 +293,7 @@ contract ActionTest is DSTest {
         jug.rely(address(action));
         flap.rely(address(action));
         flop.rely(address(action));
+        daiJoin.rely(address(action));
         median.rely(address(action));
         log.rely(address(action));
         autoLine.rely(address(action));
@@ -310,6 +321,21 @@ contract ActionTest is DSTest {
 
         action.deauthorize_test(address(vat), address(1));
         assertEq(vat.wards(address(1)), 0);
+    }
+
+    function test_delegateVat() public {
+        assertEq(vat.can(address(action), address(1)), 0);
+        action.delegateVat_test(address(1));
+        assertEq(vat.can(address(action), address(1)), 1);
+    }
+
+    function test_undelegateVat() public {
+        assertEq(vat.can(address(action), address(1)), 0);
+        action.delegateVat_test(address(1));
+        assertEq(vat.can(address(action), address(1)), 1);
+
+        action.undelegateVat_test(address(1));
+        assertEq(vat.can(address(action), address(1)), 0);
     }
 
     /****************************/
@@ -886,5 +912,28 @@ contract ActionTest is DSTest {
         DssTestNoOfficeHoursAction actionNoOfficeHours = new DssTestNoOfficeHoursAction();
         actionNoOfficeHours.execute();
         assertTrue(!actionNoOfficeHours.officeHours());
+    }
+
+
+    /*****************************/
+    /*** Collateral Onboarding ***/
+    /*****************************/
+
+    function sendPaymentFromSurplusBuffer_test() public {
+        address target = address(this);
+
+        action.delegateVat_test(address(daiJoin));
+
+        assertEq(vat.dai(target), 0);
+        assertEq(vat.sin(target), 0);
+        assertEq(daiToken.balanceOf(target), 0);
+        assertEq(vat.dai(address(vow)), 0);
+        assertEq(vat.sin(address(vow)), 0);
+        action.sendPaymentFromSurplusBuffer_test(target, 100);
+        assertEq(vat.dai(target), 0);
+        assertEq(vat.sin(target), 0);
+        assertEq(daiToken.balanceOf(target), 100 * WAD);
+        assertEq(vat.dai(address(vow)), 0);
+        assertEq(vat.sin(address(vow)), 100 * RAD);
     }
 }

--- a/src/test/DssTestAction.sol
+++ b/src/test/DssTestAction.sol
@@ -46,6 +46,14 @@ contract DssTestAction is DssAction {
         lib.deauthorize(base, ward);
     }
 
+    function delegateVat_test(address usr) public {
+        lib.delegateVat(usr);
+    }
+
+    function undelegateVat_test(address usr) public {
+        lib.undelegateVat(usr);
+    }
+
     /**************************/
     /*** Accumulating Rates ***/
     /**************************/
@@ -320,6 +328,15 @@ contract DssTestAction is DssAction {
         );
 
         addNewCollateral(co);
+    }
+
+
+    /***************/
+    /*** Payment ***/
+    /***************/
+
+    function sendPaymentFromSurplusBuffer_test(address target, uint256 amount) public {
+        lib.sendPaymentFromSurplusBuffer(target, amount);
     }
 
 }


### PR DESCRIPTION
Added method to pay out ERC20 DAI from the surplus buffer. There was a dependency of `vat.hope` as well, so I added that.

https://app.clubhouse.io/scdomaincommunityteam/story/9288/add-dai-suck-process-to-dss-exec-lib