### PR TITLE
Remove auth from flippermom when liquidations off

### DIFF
--- a/src/DssAction.sol
+++ b/src/DssAction.sol
@@ -69,13 +69,12 @@ abstract contract DssAction {
 
         address _flipperMom = DssExecLib.flipperMom();
 
-        // Allow FlipperMom to access to the ilk Flipper
-        DssExecLib.authorize(co.flip, _flipperMom);
-
         if (!co.isLiquidatable) {
-            // Remove liquidation permission from FlipperMom and Flip
-            DssExecLib.deauthorize(_flipperMom, co.flip);
-            DssExecLib.deauthorize(co.flip, _flipperMom);
+            // Disallow Cat to kick auctions in ilk Flipper
+            DssExecLib.deauthorize(co.flip, DssExecLib.cat());
+        } else {
+            // Allow FlipperMom to access to the ilk Flipper
+            DssExecLib.authorize(co.flip, DssExecLib.flipperMom());
         }
 
         if(co.isOSM) { // If pip == OSM

--- a/src/DssAction.sol
+++ b/src/DssAction.sol
@@ -69,12 +69,12 @@ abstract contract DssAction {
 
         address _flipperMom = DssExecLib.flipperMom();
 
-        if (!co.isLiquidatable) {
-            // Disallow Cat to kick auctions in ilk Flipper
-            DssExecLib.deauthorize(co.flip, DssExecLib.cat());
-        } else {
+        if (co.isLiquidatable) {
             // Allow FlipperMom to access to the ilk Flipper
             DssExecLib.authorize(co.flip, DssExecLib.flipperMom());
+        } else {
+            // Disallow Cat to kick auctions in ilk Flipper
+            DssExecLib.deauthorize(co.flip, DssExecLib.cat());
         }
 
         if(co.isOSM) { // If pip == OSM

--- a/src/DssAction.sol
+++ b/src/DssAction.sol
@@ -67,11 +67,16 @@ abstract contract DssAction {
         // Add the collateral to the system.
         DssExecLib.addCollateralBase(co.ilk, co.gem, co.join, co.flip, co.pip);
 
-        // Allow FlipperMom to access to the ilk Flipper
         address _flipperMom = DssExecLib.flipperMom();
+
+        // Allow FlipperMom to access to the ilk Flipper
         DssExecLib.authorize(co.flip, _flipperMom);
-        // Disallow Cat to kick auctions in ilk Flipper
-        if(!co.isLiquidatable) { DssExecLib.deauthorize(_flipperMom, co.flip); }
+
+        if (!co.isLiquidatable) {
+            // Remove liquidation permission from FlipperMom and Flip
+            DssExecLib.deauthorize(_flipperMom, co.flip);
+            DssExecLib.deauthorize(co.flip, _flipperMom);
+        }
 
         if(co.isOSM) { // If pip == OSM
             // Allow OsmMom to access to the TOKEN OSM

--- a/src/test/DssAction.t.sol
+++ b/src/test/DssAction.t.sol
@@ -846,12 +846,11 @@ contract ActionTest is DSTest {
         assertEq(cat.wards(address(tokenFlip)), 1);
 
         assertEq(tokenFlip.wards(address(end)),        1);
-        assertEq(tokenFlip.wards(address(flipperMom)), 1);
 
-        if (!liquidatable) assertEq(tokenFlip.wards(address(cat)), 0);
-        else               assertEq(tokenFlip.wards(address(cat)), 1);
+        uint256 liq_ = (liquidatable) ? 1 : 0;
+        assertEq(tokenFlip.wards(address(cat)), liq_);
+        assertEq(tokenFlip.wards(address(flipperMom)), liq_);
         }
-
 
         if (isOsm) {
           assertEq(OSM(tokenPip).wards(address(osmMom)), 1);


### PR DESCRIPTION
Seems we have to auth flippermom on flip before we can deauth flip on flippermom.