### PR TITLE
Move COB from DssAction to DssExecLib

### DIFF
--- a/src/DssAction.sol
+++ b/src/DssAction.sol
@@ -19,7 +19,6 @@
 
 pragma solidity ^0.6.11;
 
-import "./CollateralOpts.sol";
 import { DssExecLib } from "./DssExecLib.sol";
 
 interface OracleLike {
@@ -56,63 +55,5 @@ abstract contract DssAction {
             require(hour >= 14 && hour < 21, "Outside office hours");
         }
         _;
-    }
-
-    /*****************************/
-    /*** Collateral Onboarding ***/
-    /*****************************/
-
-    // Complete collateral onboarding logic.
-    function addNewCollateral(CollateralOpts memory co) internal {
-        // Add the collateral to the system.
-        DssExecLib.addCollateralBase(co.ilk, co.gem, co.join, co.flip, co.pip);
-
-        if (co.isLiquidatable) {
-            // Allow FlipperMom to access to the ilk Flipper
-            DssExecLib.authorize(co.flip, DssExecLib.flipperMom());
-        } else {
-            // Disallow Cat to kick auctions in ilk Flipper
-            DssExecLib.deauthorize(co.flip, DssExecLib.cat());
-        }
-
-        if(co.isOSM) { // If pip == OSM
-            // Allow OsmMom to access to the TOKEN OSM
-            DssExecLib.authorize(co.pip, DssExecLib.osmMom());
-            if (co.whitelistOSM) { // If median is src in OSM
-                // Whitelist OSM to read the Median data (only necessary if it is the first time the token is being added to an ilk)
-                DssExecLib.addReaderToMedianWhitelist(address(OracleLike(co.pip).src()), co.pip);
-            }
-            // Whitelist Spotter to read the OSM data (only necessary if it is the first time the token is being added to an ilk)
-            DssExecLib.addReaderToOSMWhitelist(co.pip, DssExecLib.spotter());
-            // Whitelist End to read the OSM data (only necessary if it is the first time the token is being added to an ilk)
-            DssExecLib.addReaderToOSMWhitelist(co.pip, DssExecLib.end());
-            // Set TOKEN OSM in the OsmMom for new ilk
-            DssExecLib.allowOSMFreeze(co.pip, co.ilk);
-        }
-        // Increase the global debt ceiling by the ilk ceiling
-        DssExecLib.increaseGlobalDebtCeiling(co.ilkDebtCeiling);
-        // Set the ilk debt ceiling
-        DssExecLib.setIlkDebtCeiling(co.ilk, co.ilkDebtCeiling);
-        // Set the ilk dust
-        DssExecLib.setIlkMinVaultAmount(co.ilk, co.minVaultAmount);
-        // Set the dunk size
-        DssExecLib.setIlkMaxLiquidationAmount(co.ilk, co.maxLiquidationAmount);
-        // Set the ilk liquidation penalty
-        DssExecLib.setIlkLiquidationPenalty(co.ilk, co.liquidationPenalty);
-
-        // Set the ilk stability fee
-        DssExecLib.setIlkStabilityFee(co.ilk, co.ilkStabilityFee, true);
-
-        // Set the ilk percentage between bids
-        DssExecLib.setIlkMinAuctionBidIncrease(co.ilk, co.bidIncrease);
-        // Set the ilk time max time between bids
-        DssExecLib.setIlkBidDuration(co.ilk, co.bidDuration);
-        // Set the ilk max auction duration
-        DssExecLib.setIlkAuctionDuration(co.ilk, co.auctionDuration);
-        // Set the ilk min collateralization ratio
-        DssExecLib.setIlkLiquidationRatio(co.ilk, co.liquidationRatio);
-
-        // Update ilk spot value in Vat
-        DssExecLib.updateCollateralPrice(co.ilk);
     }
 }

--- a/src/DssAction.sol
+++ b/src/DssAction.sol
@@ -57,34 +57,4 @@ abstract contract DssAction {
         }
         _;
     }
-
-    function addNewCollateral(CollateralOpts memory co) internal {
-
-        address[] memory _addrs = new address[](4);
-        bool[] memory _bools = new bool[](3);
-        uint256[] memory _vals = new uint256[](9);
-        _addrs[0] = co.gem;
-        _addrs[1] = co.join;
-        _addrs[2] = co.flip;
-        _addrs[3] = co.pip;
-        _bools[0] = co.isLiquidatable;
-        _bools[1] = co.isOSM;
-        _bools[2] = co.whitelistOSM;
-        _vals[0]  = co.ilkDebtCeiling;
-        _vals[1]  = co.minVaultAmount;
-        _vals[2]  = co.maxLiquidationAmount;
-        _vals[3]  = co.liquidationPenalty;
-        _vals[4]  = co.ilkStabilityFee;
-        _vals[5]  = co.bidIncrease;
-        _vals[6]  = co.bidDuration;
-        _vals[7]  = co.auctionDuration;
-        _vals[8]  = co.liquidationRatio;
-
-        DssExecLib.addNewCollateral(
-            co.ilk,
-            _addrs,
-            _bools,
-            _vals
-        );
-    }
 }

--- a/src/DssAction.sol
+++ b/src/DssAction.sol
@@ -20,6 +20,7 @@
 pragma solidity ^0.6.11;
 
 import { DssExecLib } from "./DssExecLib.sol";
+import { CollateralOpts } from "./CollateralOpts.sol";
 
 interface OracleLike {
     function src() external view returns (address);
@@ -55,5 +56,35 @@ abstract contract DssAction {
             require(hour >= 14 && hour < 21, "Outside office hours");
         }
         _;
+    }
+
+    function addNewCollateral(CollateralOpts memory co) internal {
+
+        address[] memory _addrs = new address[](4);
+        bool[] memory _bools = new bool[](3);
+        uint256[] memory _vals = new uint256[](9);
+        _addrs[0] = co.gem;
+        _addrs[1] = co.join;
+        _addrs[2] = co.flip;
+        _addrs[3] = co.pip;
+        _bools[0] = co.isLiquidatable;
+        _bools[1] = co.isOSM;
+        _bools[2] = co.whitelistOSM;
+        _vals[0]  = co.ilkDebtCeiling;
+        _vals[1]  = co.minVaultAmount;
+        _vals[2]  = co.maxLiquidationAmount;
+        _vals[3]  = co.liquidationPenalty;
+        _vals[4]  = co.ilkStabilityFee;
+        _vals[5]  = co.bidIncrease;
+        _vals[6]  = co.bidDuration;
+        _vals[7]  = co.auctionDuration;
+        _vals[8]  = co.liquidationRatio;
+
+        DssExecLib.addNewCollateral(
+            co.ilk,
+            _addrs,
+            _bools,
+            _vals
+        );
     }
 }

--- a/src/test/DssAction.t.sol
+++ b/src/test/DssAction.t.sol
@@ -18,6 +18,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 pragma solidity ^0.6.11;
+pragma experimental ABIEncoderV2;
 
 import "ds-test/test.sol";
 import "ds-token/token.sol";
@@ -791,8 +792,8 @@ contract ActionTest is DSTest {
 
         bytes32 ilk = "silver";
 
-        DSToken token     = new DSToken(ilk);
-        GemJoin tokenJoin = new GemJoin(address(vat), ilk, address(token));
+        address token     = address(new DSToken(ilk));
+        GemJoin tokenJoin = new GemJoin(address(vat), ilk, token);
         Flipper tokenFlip = new Flipper(address(vat), address(cat), ilk);
         address tokenPip  = address(new DSValue());
 
@@ -807,35 +808,28 @@ contract ActionTest is DSTest {
         tokenJoin.deny(address(this));
 
         {
-            address[] memory addresses = new address[](4);
-            addresses[0] = address(token);
-            addresses[1] = address(tokenJoin);
-            addresses[2] = address(tokenFlip);
-            addresses[3] = tokenPip;
-
-            bool[] memory oracleSettings = new bool[](3);
-            oracleSettings[0] = liquidatable;
-            oracleSettings[1] = isOsm;
-            oracleSettings[2] = medianSrc;
-
-            uint256[] memory amounts = new uint256[](9);
-            amounts[0] = 100 * MILLION;                // ilkDebtCeiling
-            amounts[1] = 100;                          // minVaultAmount
-            amounts[2] = 50 * THOUSAND;                // maxLiquidationAmount
-            amounts[3] = 1300;                         // liquidationPenalty
-            amounts[4] = 1000000001243680656318820312; // ilkStabilityFee
-            amounts[5] = 500;                          // bidIncrease
-            amounts[6] = 6 hours;                      // bidDuration
-            amounts[7] = 6 hours;                      // auctionDuration
-            amounts[8] = 15000;                        // liquidationRatio
-
             uint256 globalLine = vat.Line();
 
             action.addNewCollateral_test(
-                ilk,
-                addresses,
-                oracleSettings,
-                amounts
+                CollateralOpts({
+                    ilk:                   ilk,
+                    gem:                   token,
+                    join:                  address(tokenJoin),
+                    flip:                  address(tokenFlip),
+                    pip:                   tokenPip,
+                    isLiquidatable:        liquidatable,
+                    isOSM:                 isOsm,
+                    whitelistOSM:          medianSrc,
+                    ilkDebtCeiling:        100 * MILLION,
+                    minVaultAmount:        100,
+                    maxLiquidationAmount:  50 * THOUSAND,
+                    liquidationPenalty:    1300,
+                    ilkStabilityFee:       1000000001243680656318820312,
+                    bidIncrease:           500,
+                    bidDuration:           6 hours,
+                    auctionDuration:       6 hours,
+                    liquidationRatio:      15000
+                })
             );
 
             assertEq(vat.Line(), globalLine + 100 * MILLION * RAD);

--- a/src/test/DssExec.t.sol
+++ b/src/test/DssExec.t.sol
@@ -60,7 +60,7 @@ contract DssLibSpellAction is DssAction { // This could be changed to a library 
             auctionDuration:       6 hours,
             liquidationRatio:      15000
         });
-        DssExecLib.addNewCollateral(XMPL_A);
+        addNewCollateral(XMPL_A);
 
         DssExecLib.setIlkDebtCeiling("ETH-A", 10 * MILLION);
         DssExecLib.setIlkLiquidationPenalty("ETH-A", 1400);

--- a/src/test/DssExec.t.sol
+++ b/src/test/DssExec.t.sol
@@ -18,6 +18,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 pragma solidity ^0.6.11;
+pragma experimental ABIEncoderV2;
 
 import "ds-test/test.sol";
 import "ds-math/math.sol";
@@ -60,7 +61,7 @@ contract DssLibSpellAction is DssAction { // This could be changed to a library 
             auctionDuration:       6 hours,
             liquidationRatio:      15000
         });
-        addNewCollateral(XMPL_A);
+        DssExecLib.addNewCollateral(XMPL_A);
 
         DssExecLib.setIlkDebtCeiling("ETH-A", 10 * MILLION);
         DssExecLib.setIlkLiquidationPenalty("ETH-A", 1400);

--- a/src/test/DssExec.t.sol
+++ b/src/test/DssExec.t.sol
@@ -60,9 +60,14 @@ contract DssLibSpellAction is DssAction { // This could be changed to a library 
             auctionDuration:       6 hours,
             liquidationRatio:      15000
         });
-        addNewCollateral(XMPL_A);
+        DssExecLib.addNewCollateral(XMPL_A);
 
         DssExecLib.setIlkDebtCeiling("ETH-A", 10 * MILLION);
+        DssExecLib.setIlkLiquidationPenalty("ETH-A", 1400);
+        DssExecLib.setIlkMinAuctionBidIncrease("ETH-A", 400);
+        DssExecLib.setIlkLiquidationRatio("ETH-A", 16000);
+        DssExecLib.setIlkBidDuration("ETH-A", 3 hours);
+        DssExecLib.setIlkAuctionDuration("ETH-A", 3 hours);
         DssExecLib.setGlobalDebtCeiling(10000 * MILLION);
     }
 }
@@ -225,14 +230,14 @@ contract DssLibExecTest is DSTest, DSMath {
         (uint256 _duty,)  = jug.ilks("ETH-A");
         afterSpell.collaterals["ETH-A"] = CollateralValues({
             line:         10 * MILLION,    // In whole Dai units
-            dust:         _dust/RAD,        // In whole Dai units
-            pct:          _duty,             // In basis points
-            chop:         1300,            // In basis points
-            dunk:         _dunk/RAD,        // In whole Dai units
-            mat:          15000,           // In basis points
-            beg:          300,             // In basis points
-            ttl:          6 hours,         // In seconds
-            tau:          6 hours,         // In seconds
+            dust:         _dust/RAD,       // In whole Dai units
+            pct:          _duty,           // In basis points
+            chop:         1400,            // In basis points
+            dunk:         _dunk/RAD,       // In whole Dai units
+            mat:          16000,           // In basis points
+            beg:          400,             // In basis points
+            ttl:          3 hours,         // In seconds
+            tau:          3 hours,         // In seconds
             liquidations: 1                // 1 if enabled
         });
         // New collateral

--- a/src/test/DssTestAction.sol
+++ b/src/test/DssTestAction.sol
@@ -20,6 +20,7 @@
 pragma solidity ^0.6.11;
 
 import "../DssAction.sol";
+import "../CollateralOpts.sol";
 
 contract DssTestNoOfficeHoursAction is DssAction {
     function actions() public override {
@@ -327,7 +328,7 @@ contract DssTestAction is DssAction {
             amounts[8]            // liquidationRatio
         );
 
-        addNewCollateral(co);
+        DssExecLib.addNewCollateral(co);
     }
 
 

--- a/src/test/DssTestAction.sol
+++ b/src/test/DssTestAction.sol
@@ -18,9 +18,9 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 pragma solidity ^0.6.11;
+pragma experimental ABIEncoderV2;
 
 import "../DssAction.sol";
-import "../CollateralOpts.sol";
 
 contract DssTestNoOfficeHoursAction is DssAction {
     function actions() public override {
@@ -303,32 +303,9 @@ contract DssTestAction is DssAction {
 
 
     function addNewCollateral_test(
-        bytes32          ilk,
-        address[] memory addresses,
-        bool[] memory    oracleSettings,
-        uint256[] memory amounts
+        CollateralOpts memory co
     ) public {
-        CollateralOpts memory co = CollateralOpts(
-            ilk,
-            addresses[0],
-            addresses[1],
-            addresses[2],
-            addresses[3],
-            oracleSettings[0],
-            oracleSettings[1],
-            oracleSettings[2],
-            amounts[0],           // ilkDebtCeiling
-            amounts[1],           // minVaultAmount
-            amounts[2],           // maxLiquidationAmount
-            amounts[3],           // liquidationPenalty
-            amounts[4],           // ilkStabilityFee
-            amounts[5],           // bidIncrease
-            amounts[6],           // bidDuration
-            amounts[7],           // auctionDuration
-            amounts[8]            // liquidationRatio
-        );
-
-        addNewCollateral(co);
+        DssExecLib.addNewCollateral(co);
     }
 
 

--- a/src/test/DssTestAction.sol
+++ b/src/test/DssTestAction.sol
@@ -328,7 +328,7 @@ contract DssTestAction is DssAction {
             amounts[8]            // liquidationRatio
         );
 
-        DssExecLib.addNewCollateral(co);
+        addNewCollateral(co);
     }
 
 


### PR DESCRIPTION
* Moves collateral onboarding from the action to the lib
* Updates some tests to not rely on mainnet state

Still wondering whether we should also import `CollateralOpts` into DssAction so that it's available to the spellcrafter, otherwise they will need to do a separate explicit import.