### PR TITLE
Make description required in DssAction

### DIFF
--- a/src/DssAction.sol
+++ b/src/DssAction.sol
@@ -53,6 +53,11 @@ abstract contract DssAction {
     //   By keeping this function public we allow simulations of `execute()` on the actions outside of the cast time.
     function actions() public virtual;
 
+    // Provides a descriptive tag for bot consumption
+    // This should be modified weekly to provide a summary of the actions
+    // Hash: seth keccak -- "$(wget https://<executive-vote-canonical-post> -q -O - 2>/dev/null)"
+    function description() external virtual returns (string memory);
+
     // Returns the next available cast time
     function nextCastTime(uint256 eta) external returns (uint256 castTime) {
         require(eta <= uint40(-1));

--- a/src/DssAction.sol
+++ b/src/DssAction.sol
@@ -56,7 +56,7 @@ abstract contract DssAction {
     // Provides a descriptive tag for bot consumption
     // This should be modified weekly to provide a summary of the actions
     // Hash: seth keccak -- "$(wget https://<executive-vote-canonical-post> -q -O - 2>/dev/null)"
-    function description() external virtual returns (string memory);
+    function description() external virtual view returns (string memory);
 
     // Returns the next available cast time
     function nextCastTime(uint256 eta) external returns (uint256 castTime) {

--- a/src/DssExec.sol
+++ b/src/DssExec.sol
@@ -31,6 +31,7 @@ interface Changelog {
 
 interface SpellAction {
     function officeHours() external view returns (bool);
+    function description() external view returns (string memory);
     function nextCastTime(uint256) external view returns (uint256);
 }
 
@@ -48,7 +49,9 @@ contract DssExec {
     // Provides a descriptive tag for bot consumption
     // This should be modified weekly to provide a summary of the actions
     // Hash: seth keccak -- "$(wget https://<executive-vote-canonical-post> -q -O - 2>/dev/null)"
-    string                  public description;
+    function description() external view returns (string memory) {
+        return SpellAction(action).description();
+    }
 
     function officeHours() external view returns (bool) {
         return SpellAction(action).officeHours();
@@ -61,9 +64,8 @@ contract DssExec {
     // @param _description  A string description of the spell
     // @param _expiration   The timestamp this spell will expire. (Ex. now + 30 days)
     // @param _spellAction  The address of the spell action
-    constructor(string memory _description, uint256 _expiration, address _spellAction) public {
+    constructor(uint256 _expiration, address _spellAction) public {
         pause       = PauseAbstract(log.getAddress("MCD_PAUSE"));
-        description = _description;
         expiration  = _expiration;
         action      = _spellAction;
 

--- a/src/test/DssExec.t.sol
+++ b/src/test/DssExec.t.sol
@@ -51,6 +51,10 @@ interface ClipFabLike {
 
 contract DssLibSpellAction is DssAction { // This could be changed to a library if the lib is hardcoded and the constructor removed
 
+    function description() external override returns (string memory) {
+        return "DssLibSpellAction Description";
+    }
+
     uint256 constant MILLION  = 10 ** 6;
 
     function actions() public override {
@@ -239,7 +243,6 @@ contract DssLibExecTest is DSTest, DSMath {
         castPreviousSpell();
 
         spell = new DssExec(
-            "A test dss exec spell",                    // Description
             now + 30 days,                              // Expiration
             address(new DssLibSpellAction())
         );

--- a/src/test/DssExec.t.sol
+++ b/src/test/DssExec.t.sol
@@ -51,7 +51,7 @@ interface ClipFabLike {
 
 contract DssLibSpellAction is DssAction { // This could be changed to a library if the lib is hardcoded and the constructor removed
 
-    function description() external override returns (string memory) {
+    function description() external override view returns (string memory) {
         return "DssLibSpellAction Description";
     }
 

--- a/src/test/DssTestAction.sol
+++ b/src/test/DssTestAction.sol
@@ -23,6 +23,10 @@ pragma experimental ABIEncoderV2;
 import "../DssAction.sol";
 
 contract DssTestNoOfficeHoursAction is DssAction {
+    function description() public override returns (string memory) {
+        return "No Office Hours Action";
+    }
+
     function actions() public override {
         require(!officeHours());
     }
@@ -33,6 +37,10 @@ contract DssTestNoOfficeHoursAction is DssAction {
 }
 
 contract DssTestAction is DssAction {
+
+    function description() external override returns (string memory) {
+        return "DssTestAction";
+    }
 
     function actions() public override {}
 

--- a/src/test/DssTestAction.sol
+++ b/src/test/DssTestAction.sol
@@ -23,7 +23,7 @@ pragma experimental ABIEncoderV2;
 import "../DssAction.sol";
 
 contract DssTestNoOfficeHoursAction is DssAction {
-    function description() public override returns (string memory) {
+    function description() public override view returns (string memory) {
         return "No Office Hours Action";
     }
 
@@ -38,7 +38,7 @@ contract DssTestNoOfficeHoursAction is DssAction {
 
 contract DssTestAction is DssAction {
 
-    function description() external override returns (string memory) {
+    function description() external override view returns (string memory) {
         return "DssTestAction";
     }
 


### PR DESCRIPTION
Moves the description to a required implementation of DssAction. 
This means that it's no longer necessary to pass the description as a parameter of DssExec.
Saves some gas, and fails compilation if it's missing from the spell, now.