### PR TITLE
Test lerp ilk and upd readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,12 @@ DssExecLib.setChangelogAddress("MCD_CLIP_CALC_XMPL-A", xmpl_calc);
 ### Payments
 - `sendPaymentFromSurplusBuffer(address _target, uint256 _amount)`: Send a payment in ERC20 DAI from the surplus buffer.
 
+### Misc
+
+- `function linearInterpolation(bytes32 _name, address _target, bytes32 _what, uint256 _startTime, uint256 _start, uint256 _end, uint256 _duration)`: Deploys a new general lerp contract with the associated parameters and returns the `address` of the contract.
+
+- `function linearInterpolation(bytes32 _name, address _target, bytes32 _ilk, bytes32 _what, uint256 _startTime, uint256 _start, uint256 _end, uint256 _duration)`: Deploys a new lerp module specific to an ilk and returns the `address` of the contract.
+
 ## Testing
 
 ```


### PR DESCRIPTION
Adds a test of the ilk-specific `linearInterpolation` function and updates the readme to include lerp library calls.