### PR TITLE
Fix LP oracle whitelisting and clean up seldom used oracle functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,15 +165,12 @@ Below is an outline of all functions used in the library.
 - `initExponentialDecrease(address _calc, uint256 _pct_bps)`: Initialize the variables in an ExponentialDecrease calculator.
 
 ### Oracle Management
-- `addWritersToMedianWhitelist(address _median, address[] memory _feeds)`: Adds oracle feeds to the Median's writer whitelist, allowing the feeds to write prices.
-- `removeWritersFromMedianWhitelist(address _median, address[] memory _feeds)`: Removes oracle feeds to the Median's writer whitelist, disallowing the feeds to write prices.
-- `addReadersToMedianWhitelist(address _median, address[] memory _readers)`: Adds addresses to the Median's reader whitelist, allowing the addresses to read prices from the median.
-- `addReaderToMedianWhitelist(address _median, address _reader)`: Adds an address to the Median's reader whitelist, allowing the address to read prices from the median.
-- `removeReadersFromMedianWhitelist(address _median, address[] memory _readers)`: Removes addresses from the Median's reader whitelist, disallowing the addresses to read prices from the median.
-- `removeReaderFromMedianWhitelist(address _median, address _reader)`: Removes an address to the Median's reader whitelist, disallowing the address to read prices from the median.
+- `whitelistOracleMedians(address _oracle)`: Pass an OSM or UNIV2LP oracle to enable it to read the underlying medianizer.
+- `addReaderToWhitelist(address _oracle, address _reader)`: Adds an address to the OSM or Median's reader whitelist, allowing the address to read prices.
+- `removeReaderFromWhitelist(address _oracle, address _reader)`: Removes an address to the OSM or Median's reader whitelist, disallowing the address to read prices.
+- `addReaderToWhitelistCall(address _oracle, address _reader)`: Adds an address to the OSM or Median's reader whitelist, allowing the address to read prices.
+- `removeReaderFromWhitelistCall(address _oracle, address _reader)`: Removes an address to the OSM or Median's reader whitelist, disallowing the address to read prices.
 - `setMedianWritersQuorum(address _median, uint256 _minQuorum)`: Sets the minimum number of valid messages from whitelisted oracle feeds needed to update median price.
-- `addReaderToOSMWhitelist(address _osm, address _reader)`: Adds an address to the Median's reader whitelist, allowing the address to read prices from the OSM.
-- `removeReaderFromOSMWhitelist(address _osm, address _reader)`: Removes an address to the Median's reader whitelist, disallowing the address to read prices from the OSM.
 - `allowOSMFreeze(address _osm, bytes32 _ilk)`: Add OSM address to OSM mom, allowing it to be frozen by governance.
 
 ### Collateral Onboarding

--- a/src/DssExecLib.sol
+++ b/src/DssExecLib.sol
@@ -833,61 +833,44 @@ library DssExecLib {
         if (ok) {
             // Token is an LP oracle
             address median0 = abi.decode(data, (address));
-            addReaderToMedianWhitelist(median0, _oracle);
-            addReaderToMedianWhitelist(OracleLike(_oracle).orb1(), _oracle);
+            addReaderToWhitelistCall(median0, _oracle);
+            addReaderToWhitelistCall(OracleLike(_oracle).orb1(), _oracle);
         } else {
             // Standard OSM
-            addReaderToMedianWhitelist(OracleLike(_oracle).src(), _oracle);
+            addReaderToWhitelistCall(OracleLike(_oracle).src(), _oracle);
         }
     }
-
     /**
-        @dev Adds oracle feeds to the Median's writer whitelist, allowing the feeds to write prices.
-        @param _median  Median core contract address
-        @param _feeds   Array of oracle feed addresses to add to whitelist
+        @dev Adds an address to the OSM or Median's reader whitelist, allowing the address to read prices.
+        @param _oracle        Oracle Security Module (OSM) or Median core contract address
+        @param _reader     Address to add to whitelist
     */
-    function addWritersToMedianWhitelist(address _median, address[] memory _feeds) public {
-        OracleLike(_median).lift(_feeds);
+    function addReaderToWhitelist(address _oracle, address _reader) public {
+        OracleLike(_oracle).kiss(_reader);
     }
     /**
-        @dev Removes oracle feeds to the Median's writer whitelist, disallowing the feeds to write prices.
-        @param _median  Median core contract address
-        @param _feeds   Array of oracle feed addresses to remove from whitelist
+        @dev Removes an address to the OSM or Median's reader whitelist, disallowing the address to read prices.
+        @param _oracle     Oracle Security Module (OSM) or Median core contract address
+        @param _reader     Address to remove from whitelist
     */
-    function removeWritersFromMedianWhitelist(address _median, address[] memory _feeds) public {
-        OracleLike(_median).drop(_feeds);
+    function removeReaderFromWhitelist(address _oracle, address _reader) public {
+        OracleLike(_oracle).diss(_reader);
     }
     /**
-        @dev Adds addresses to the Median's reader whitelist, allowing the addresses to read prices from the median.
-        @param _median  Median core contract address
-        @param _readers Array of addresses to add to whitelist
-    */
-    function addReadersToMedianWhitelist(address _median, address[] memory _readers) public {
-        OracleLike(_median).kiss(_readers);
-    }
-    /**
-        @dev Adds an address to the Median's reader whitelist, allowing the address to read prices from the median.
-        @param _median  Median core contract address
+        @dev Adds an address to the OSM or Median's reader whitelist, allowing the address to read prices.
+        @param _oracle  OSM or Median core contract address
         @param _reader  Address to add to whitelist
     */
-    function addReaderToMedianWhitelist(address _median, address _reader) public {
-        OracleLike(_median).kiss(_reader);
+    function addReaderToWhitelistCall(address _oracle, address _reader) public {
+        (bool ok,) = _oracle.call(abi.encodeWithSignature("kiss(address)", _reader)); ok;
     }
     /**
-        @dev Removes addresses from the Median's reader whitelist, disallowing the addresses to read prices from the median.
-        @param _median  Median core contract address
-        @param _readers Array of addresses to remove from whitelist
-    */
-    function removeReadersFromMedianWhitelist(address _median, address[] memory _readers) public {
-        OracleLike(_median).diss(_readers);
-    }
-    /**
-        @dev Removes an address to the Median's reader whitelist, disallowing the address to read prices from the median.
-        @param _median  Median core contract address
+        @dev Removes an address to the OSM or Median's reader whitelist, disallowing the address to read prices.
+        @param _oracle  Oracle Security Module (OSM) or Median core contract address
         @param _reader  Address to remove from whitelist
     */
-    function removeReaderFromMedianWhitelist(address _median, address _reader) public {
-        OracleLike(_median).diss(_reader);
+    function removeReaderFromWhitelistCall(address _oracle, address _reader) public {
+        (bool ok,) = _oracle.call(abi.encodeWithSignature("diss(address)", _reader)); ok;
     }
     /**
         @dev Sets the minimum number of valid messages from whitelisted oracle feeds needed to update median price.
@@ -896,22 +879,6 @@ library DssExecLib {
     */
     function setMedianWritersQuorum(address _median, uint256 _minQuorum) public {
         OracleLike(_median).setBar(_minQuorum);
-    }
-    /**
-        @dev Adds an address to the Median's reader whitelist, allowing the address to read prices from the OSM.
-        @param _osm        Oracle Security Module (OSM) core contract address
-        @param _reader     Address to add to whitelist
-    */
-    function addReaderToOSMWhitelist(address _osm, address _reader) public {
-        OracleLike(_osm).kiss(_reader);
-    }
-    /**
-        @dev Removes an address to the Median's reader whitelist, disallowing the address to read prices from the OSM.
-        @param _osm        Oracle Security Module (OSM) core contract address
-        @param _reader     Address to remove from whitelist
-    */
-    function removeReaderFromOSMWhitelist(address _osm, address _reader) public {
-        OracleLike(_osm).diss(_reader);
     }
     /**
         @dev Add OSM address to OSM mom, allowing it to be frozen by governance.
@@ -1011,13 +978,13 @@ library DssExecLib {
                 whitelistOracleMedians(co.pip);
             }
             // Whitelist Spotter to read the OSM data (only necessary if it is the first time the token is being added to an ilk)
-            addReaderToOSMWhitelist(co.pip, spotter());
+            addReaderToWhitelist(co.pip, spotter());
             // Whitelist Clipper on pip
-            addReaderToOSMWhitelist(co.pip, co.clip);
+            addReaderToWhitelist(co.pip, co.clip);
             // Allow the clippermom to access the feed
-            addReaderToOSMWhitelist(co.pip, clipperMom_);
+            addReaderToWhitelist(co.pip, clipperMom_);
             // Whitelist End to read the OSM data (only necessary if it is the first time the token is being added to an ilk)
-            addReaderToOSMWhitelist(co.pip, end());
+            addReaderToWhitelist(co.pip, end());
             // Set TOKEN OSM in the OsmMom for new ilk
             allowOSMFreeze(co.pip, co.ilk);
         }

--- a/src/test/DssAction.t.sol
+++ b/src/test/DssAction.t.sol
@@ -779,75 +779,35 @@ contract ActionTest is DSTest {
         assertEq(med1.bud(address(lorc)), 1);
     }
 
-    function test_addWritersToMedianWhitelist() public {
-        address[] memory feeds = new address[](2);
-        feeds[0] = address(this);   // Random addresses since 0x1 and 0x2 didnt work with bitshift
-        feeds[1] = address(action); // Random addresses since 0x1 and 0x2 didnt work with bitshift
+    function test_whitelistOracleWithDSValue_LP() public {
+        // Should not fail for LP tokens if one or more oracles are DSValue
+        address token0 = address(new DSToken("nil"));
+        address token1 = address(new DSToken("one"));
+        DSValue med0   = new DSValue();
+        DSValue med1   = new DSValue();
+        address lperc  = address(new UniPairMock(token0, token1));
+        med0.poke(bytes32(uint256(100)));
+        med1.poke(bytes32(uint256(100)));
+        UNIV2LPOracle lorc = new UNIV2LPOracle(address(lperc), "NILONE", address(med0), address(med1));
 
-        assertEq(median.orcl(feeds[0]), 0);
-        assertEq(median.orcl(feeds[1]), 0);
-        action.addWritersToMedianWhitelist_test(address(median), feeds);
-        assertEq(median.orcl(feeds[0]), 1);
-        assertEq(median.orcl(feeds[1]), 1);
+        action.whitelistOracleMedians_test(address(lorc));
     }
 
-    function test_removeWritersFromMedianWhitelist() public {
-        address[] memory feeds = new address[](2);
-        feeds[0] = address(this);   // Random addresses since 0x1 and 0x2 didnt work with bitshift
-        feeds[1] = address(action); // Random addresses since 0x1 and 0x2 didnt work with bitshift
-
-        assertEq(median.orcl(feeds[0]), 0);
-        assertEq(median.orcl(feeds[1]), 0);
-        action.addWritersToMedianWhitelist_test(address(median), feeds);
-        assertEq(median.orcl(feeds[0]), 1);
-        assertEq(median.orcl(feeds[1]), 1);
-        action.removeWritersFromMedianWhitelist_test(address(median), feeds);
-        assertEq(median.orcl(feeds[0]), 0);
-        assertEq(median.orcl(feeds[1]), 0);
-    }
-
-    function test_addReadersToMedianWhitelist() public {
-        address[] memory readers = new address[](2);
-        readers[0] = address(1);
-        readers[1] = address(2);
-
-        assertEq(median.bud(address(1)), 0);
-        assertEq(median.bud(address(2)), 0);
-        action.addReadersToMedianWhitelist_test(address(median), readers);
-        assertEq(median.bud(address(1)), 1);
-        assertEq(median.bud(address(2)), 1);
-    }
-
-    function test_removeReadersFromMedianWhitelist() public {
-        address[] memory readers = new address[](2);
-        readers[0] = address(1);
-        readers[1] = address(2);
-
-        assertEq(median.bud(address(1)), 0);
-        assertEq(median.bud(address(2)), 0);
-        action.addReadersToMedianWhitelist_test(address(median), readers);
-        assertEq(median.bud(address(1)), 1);
-        assertEq(median.bud(address(2)), 1);
-        action.removeReadersFromMedianWhitelist_test(address(median), readers);
-        assertEq(median.bud(address(1)), 0);
-        assertEq(median.bud(address(2)), 0);
-    }
-
-    function test_addReaderToMedianWhitelist() public {
+    function test_addReaderToWhitelistCall() public {
         address reader = address(1);
 
         assertEq(median.bud(address(1)), 0);
-        action.addReaderToMedianWhitelist_test(address(median), reader);
+        action.addReaderToWhitelistCall_test(address(median), reader);
         assertEq(median.bud(address(1)), 1);
     }
 
-    function test_removeReaderFromMedianWhitelist() public {
+    function test_removeReaderFromWhitelistCall() public {
         address reader = address(1);
 
         assertEq(median.bud(address(1)), 0);
-        action.addReaderToMedianWhitelist_test(address(median), reader);
+        action.addReaderToWhitelistCall_test(address(median), reader);
         assertEq(median.bud(address(1)), 1);
-        action.removeReaderFromMedianWhitelist_test(address(median), reader);
+        action.removeReaderFromWhitelistCall_test(address(median), reader);
         assertEq(median.bud(address(1)), 0);
     }
 
@@ -856,12 +816,12 @@ contract ActionTest is DSTest {
         assertEq(median.bar(), 11);
     }
 
-    function test_addReaderToOSMWhitelist() public {
+    function test_addReaderToWhitelist() public {
         OSM osm = ilks["gold"].osm;
         address reader = address(1);
 
         assertEq(osm.bud(address(1)), 0);
-        action.addReaderToOSMWhitelist_test(address(osm), reader);
+        action.addReaderToWhitelist_test(address(osm), reader);
         assertEq(osm.bud(address(1)), 1);
     }
 
@@ -870,9 +830,9 @@ contract ActionTest is DSTest {
         address reader = address(1);
 
         assertEq(osm.bud(address(1)), 0);
-        action.addReaderToOSMWhitelist_test(address(osm), reader);
+        action.addReaderToWhitelist_test(address(osm), reader);
         assertEq(osm.bud(address(1)), 1);
-        action.removeReaderFromOSMWhitelist_test(address(osm), reader);
+        action.removeReaderFromWhitelist_test(address(osm), reader);
         assertEq(osm.bud(address(1)), 0);
     }
 

--- a/src/test/DssTestAction.sol
+++ b/src/test/DssTestAction.sol
@@ -294,40 +294,24 @@ contract DssTestAction is DssAction {
         DssExecLib.whitelistOracleMedians(oracle);
     }
 
-    function addWritersToMedianWhitelist_test(address medianizer, address[] memory feeds) public {
-        DssExecLib.addWritersToMedianWhitelist(medianizer, feeds);
+    function addReaderToWhitelistCall_test(address medianizer, address reader) public {
+        DssExecLib.addReaderToWhitelistCall(medianizer, reader);
     }
 
-    function removeWritersFromMedianWhitelist_test(address medianizer, address[] memory feeds) public {
-        DssExecLib.removeWritersFromMedianWhitelist(medianizer, feeds);
-    }
-
-    function addReadersToMedianWhitelist_test(address medianizer, address[] memory readers) public {
-        DssExecLib.addReadersToMedianWhitelist(medianizer, readers);
-    }
-
-    function addReaderToMedianWhitelist_test(address medianizer, address reader) public {
-        DssExecLib.addReaderToMedianWhitelist(medianizer, reader);
-    }
-
-    function removeReadersFromMedianWhitelist_test(address medianizer, address[] memory readers) public {
-        DssExecLib.removeReadersFromMedianWhitelist(medianizer, readers);
-    }
-
-    function removeReaderFromMedianWhitelist_test(address medianizer, address reader) public {
-        DssExecLib.removeReaderFromMedianWhitelist(medianizer, reader);
+    function removeReaderFromWhitelistCall_test(address medianizer, address reader) public {
+        DssExecLib.removeReaderFromWhitelistCall(medianizer, reader);
     }
 
     function setMedianWritersQuorum_test(address medianizer, uint256 minQuorum) public {
         DssExecLib.setMedianWritersQuorum(medianizer, minQuorum);
     }
 
-    function addReaderToOSMWhitelist_test(address osm, address reader) public {
-        DssExecLib.addReaderToOSMWhitelist(osm, reader);
+    function addReaderToWhitelist_test(address osm, address reader) public {
+        DssExecLib.addReaderToWhitelist(osm, reader);
     }
 
-    function removeReaderFromOSMWhitelist_test(address osm, address reader) public {
-        DssExecLib.removeReaderFromOSMWhitelist(osm, reader);
+    function removeReaderFromWhitelist_test(address osm, address reader) public {
+        DssExecLib.removeReaderFromWhitelist(osm, reader);
     }
 
     function allowOSMFreeze_test(address osm, bytes32 ilk) public {


### PR DESCRIPTION
* Fixes a bug where a UNIV2 token onboarding with a DSValue as one of the price sources will fail.
* Simplifies the oracle functions by removing differentiation between OSM and Median
* Removes feed array addition of oracle readers from the exec lib.