### PR TITLE
Fix LerpLike `tick` Interface in DssExecLib

### DIFF
--- a/src/DssExecLib.sol
+++ b/src/DssExecLib.sol
@@ -122,7 +122,7 @@ interface LerpFactoryLike {
 }
 
 interface LerpLike {
-    function tick() external;
+    function tick() external returns (uint256);
 }
 
 


### PR DESCRIPTION
- Add missing `tick` return value.