### PR TITLE
make office hours explicit

### DIFF
--- a/src/DssAction.sol
+++ b/src/DssAction.sol
@@ -39,9 +39,7 @@ abstract contract DssAction {
     // Office Hours defaults to true by default.
     //   To disable office hours, override this function and
     //    return false in the inherited action.
-    function officeHours() public view virtual returns (bool) {
-        return true;
-    }
+    function officeHours() public view virtual returns (bool);
 
     // DssExec calls execute. We limit this function subject to officeHours modifier.
     function execute() external limited {

--- a/src/test/DssExec.t.sol
+++ b/src/test/DssExec.t.sol
@@ -55,6 +55,10 @@ contract DssLibSpellAction is DssAction { // This could be changed to a library 
         return "DssLibSpellAction Description";
     }
 
+    function officeHours() public view override returns (bool) {
+        return true;
+    }
+
     uint256 constant MILLION  = 10 ** 6;
 
     function actions() public override {

--- a/src/test/DssTestAction.sol
+++ b/src/test/DssTestAction.sol
@@ -42,6 +42,10 @@ contract DssTestAction is DssAction {
         return "DssTestAction";
     }
 
+    function officeHours() public view override returns (bool) {
+        return true;
+    }
+
     function actions() public override {}
 
     function canCast_test(uint40 ts, bool officeHours) public pure returns (bool) {


### PR DESCRIPTION
We should make office hours always explicit in the spells.