### PR TITLE
Allow for reschedule of dropped exec

### DIFF
--- a/src/DssExec.sol
+++ b/src/DssExec.sol
@@ -79,6 +79,7 @@ contract DssExec {
 
     function schedule() public {
         require(block.timestamp <= expiration, "This contract has expired");
+        require(!done, "spell-already-cast");
         require(eta == 0 ||
                 pause.plans(keccak256(abi.encode(action, tag, sig, eta))) == false,
                 "This spell has already been scheduled");


### PR DESCRIPTION
It may be possible for an exec to be scheduled by a vote, and then dropped from the pause by a competing hat.

This change allows a spell to be re-scheduled in the case where it is scheduled, dropped, and then re-raised to the hat.