### PR TITLE
fix ilk debt ceiling global sync and skip drip on onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Below is an outline of all functions used in the library.
 ### Collateral Management
 
 - `setIlkDebtCeiling(bytes32 _ilk, uint256 _amount)`: Set a collateral debt ceiling.
+- `setIlkDebtCeiling(bytes32 _ilk, uint256 _amount, bool _global)`: Set a collateral debt ceiling and optionally adjust the global line by the delta.
 - `increaseIlkDebtCeiling(bytes32 _ilk, uint256 _amount, bool _global)`: Raise the debt ceiling of a particular ilk.
 - `decreaseIlkDebtCeiling(bytes32 _ilk, uint256 _amount, bool _global)`: Lower the debt ceiling of a particular ilk.
 - `setRWAIlkDebtCeiling(bytes32 _ilk, uint256 _ceiling, uint256 _price)`: Set the debt ceiling for a RWA collateral. This requires also a new oracle price.

--- a/src/DssAction.t.sol
+++ b/src/DssAction.t.sol
@@ -689,6 +689,32 @@ contract DssActionTest is Test {
         assertEq(line, 100 * MILLION * RAD);
     }
 
+    function test_setIlkDebtCeilingUpdatesGlobalLine() public {
+        uint256 globalLine = vat.Line();
+        (,,, uint256 goldLineBefore,) = vat.ilks("gold");
+
+        action.setIlkDebtCeiling_global_test("gold", 100 * MILLION);
+        (,,, uint256 line,) = vat.ilks("gold");
+        assertEq(line, 100 * MILLION * RAD);
+        assertEq(vat.Line(), globalLine + 100 * MILLION * RAD - goldLineBefore);
+
+        uint256 globalAfterFirst = vat.Line();
+        action.setIlkDebtCeiling_global_test("gold", 40 * MILLION);
+        (,,, line,) = vat.ilks("gold");
+        assertEq(line, 40 * MILLION * RAD);
+        assertEq(vat.Line(), globalAfterFirst - (100 * MILLION - 40 * MILLION) * RAD);
+    }
+
+    function test_setIlkDebtCeilingToZeroUpdatesGlobalLine() public {
+        action.setIlkDebtCeiling_test("gold", 100 * MILLION);
+        uint256 globalLine = vat.Line();
+
+        action.setIlkDebtCeiling_global_test("gold", 0);
+        (,,, uint256 line,) = vat.ilks("gold");
+        assertEq(line, 0);
+        assertEq(vat.Line(), globalLine - 100 * MILLION * RAD);
+    }
+
     function test_increaseIlkDebtCeiling() public {
         action.setGlobalDebtCeiling_test(100 * MILLION);
         action.setIlkDebtCeiling_test("gold", 100 * MILLION); // Setup

--- a/src/DssExecLib.sol
+++ b/src/DssExecLib.sol
@@ -726,8 +726,28 @@ library DssExecLib {
     /// @param _ilk The ilk to update (ex. bytes32("ETH-A"))
     /// @param _amount The amount to set (ex. 10m amount == 10000000)
     function setIlkDebtCeiling(bytes32 _ilk, uint256 _amount) public {
+        setIlkDebtCeiling(_ilk, _amount, false);
+    }
+
+    /// @dev Set a collateral debt ceiling. Amount will be converted to the correct internal precision.
+    /// @param _ilk The ilk to update (ex. bytes32("ETH-A"))
+    /// @param _amount The amount to set (ex. 10m amount == 10000000)
+    /// @param _global If true, adjusts the global debt ceiling by the delta between the new and previous ilk line
+    function setIlkDebtCeiling(bytes32 _ilk, uint256 _amount, bool _global) public {
         require(_amount < WAD); // "LibDssExec/incorrect-ilk-line-precision"
-        setValue(vat(), _ilk, "line", _amount * RAD);
+        address _vat = vat();
+        if (_global) {
+            (,,, uint256 oldLine,) = DssVat(_vat).ilks(_ilk);
+            uint256 newLine = _amount * RAD;
+            setValue(_vat, _ilk, "line", newLine);
+            if (newLine > oldLine) {
+                increaseGlobalDebtCeiling((newLine - oldLine) / RAD);
+            } else if (newLine < oldLine) {
+                decreaseGlobalDebtCeiling((oldLine - newLine) / RAD);
+            }
+        } else {
+            setValue(_vat, _ilk, "line", _amount * RAD);
+        }
     }
 
     /// @dev Increase a collateral debt ceiling. Amount will be converted to the correct internal precision.
@@ -1083,18 +1103,16 @@ library DssExecLib {
             allowOSMFreeze(co.pip, co.ilk);
         }
 
-        // Increase the global debt ceiling by the ilk ceiling
-        increaseGlobalDebtCeiling(co.ilkDebtCeiling);
-        // Set the ilk debt ceiling
-        setIlkDebtCeiling(co.ilk, co.ilkDebtCeiling);
+        // Set the ilk debt ceiling and keep the global line in sync
+        setIlkDebtCeiling(co.ilk, co.ilkDebtCeiling, true);
         // Set the hole size
         setIlkMaxLiquidationAmount(co.ilk, co.maxLiquidationAmount);
         // Set the ilk dust
         setIlkMinVaultAmount(co.ilk, co.minVaultAmount);
         // Set the ilk liquidation penalty
         setIlkLiquidationPenalty(co.ilk, co.liquidationPenalty);
-        // Set the ilk stability fee
-        setIlkStabilityFee(co.ilk, co.ilkStabilityFee, true);
+        // Set the ilk stability fee (no drip: ilk was just initialized in addCollateralBase)
+        setIlkStabilityFee(co.ilk, co.ilkStabilityFee, false);
         // Set the auction starting price multiplier
         setStartingPriceMultiplicativeFactor(co.ilk, co.startingPriceFactor);
         // Set the amount of time before an auction resets.

--- a/src/mocks/MockDssSpellAction.sol
+++ b/src/mocks/MockDssSpellAction.sol
@@ -196,6 +196,10 @@ contract MockDssSpellAction is DssAction {
         DssExecLib.setIlkDebtCeiling(ilk, amount);
     }
 
+    function setIlkDebtCeiling_global_test(bytes32 ilk, uint256 amount) public {
+        DssExecLib.setIlkDebtCeiling(ilk, amount, true);
+    }
+
     function increaseIlkDebtCeiling_test(bytes32 ilk, uint256 amount) public {
         DssExecLib.increaseIlkDebtCeiling(ilk, amount, true);
     }


### PR DESCRIPTION
hey team, moondev here. was poking at spell helpers and landed two fixes tied to open issues #69 and #70.

first, `setIlkDebtCeiling` could set an ilk line without touching global `Line`. that bites when you zero out an ilk dc but global stays inflated, or when you want one call to keep them aligned. added an optional `_global` flag that bumps global by the delta (same idea as increase/decrease ilk helpers). `addNewCollateral` now uses that instead of separate increase + set calls.

second, `addNewCollateral` was calling `setIlkStabilityFee` with drip enabled right after `jug.init`. nothing to accrue yet, just extra gas and a pointless drip on a fresh ilk. flipped that to `false`.

added tests for the global sync path and zeroing an ilk line. `forge build` is clean on my side; fork tests still want `ETH_RPC_URL` for mainnet.

closes #69
closes #70